### PR TITLE
Implement Shelly Gen2 HTTP digest auth

### DIFF
--- a/.github/workflows/chart_release.yml
+++ b/.github/workflows/chart_release.yml
@@ -9,12 +9,11 @@ permissions:
   contents: write
   packages: write
 
-jobs:  
+jobs:
   release:
-    # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
-    # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
     permissions:
       contents: write
+      packages: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -39,9 +38,9 @@ jobs:
         uses: appany/helm-oci-chart-releaser@v0.4.2
         with:
           name: shelly-exporter
-          repository: supporterino
+          repository: ${{ github.repository_owner }}
           tag: ${{ steps.read-chart-version.outputs.chart_version }}
           registry: ghcr.io
           registry_username: ${{ github.repository_owner }}
-          registry_password: ${{ secrets.TOKEN }}
+          registry_password: ${{ secrets.GITHUB_TOKEN }}
           update_dependencies: 'true' # Defaults to false

--- a/.github/workflows/chart_release.yml
+++ b/.github/workflows/chart_release.yml
@@ -33,14 +33,15 @@ jobs:
         run: |
           version=$(yq '.version' < charts/shelly-exporter/Chart.yaml)
           echo "chart_version=$version" >> $GITHUB_OUTPUT
+          echo "owner=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
 
       - name: Chart | Push
         uses: appany/helm-oci-chart-releaser@v0.4.2
         with:
           name: shelly-exporter
-          repository: ${{ github.repository_owner }}
+          repository: ${{ steps.read-chart-version.outputs.owner }}
           tag: ${{ steps.read-chart-version.outputs.chart_version }}
           registry: ghcr.io
-          registry_username: ${{ github.repository_owner }}
+          registry_username: ${{ steps.read-chart-version.outputs.owner }}
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           update_dependencies: 'true' # Defaults to false

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96 # v5.6.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -38,4 +38,4 @@ jobs:
           version: "~> v2"
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o shelly_exporter ./cmd/exporter
 
 FROM scratch
 
-COPY config.yaml /
 COPY --from=build /app/shelly_exporter .
 
-ENTRYPOINT ["/shelly_exporter", "-config", "config.yaml"]
+ENTRYPOINT ["/shelly_exporter"]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This fork replaces the device-type switch statement with **dynamic component dis
 
 - **Dynamic component discovery** (`client/api_client.go`) - parses `Shelly.GetStatus` response keys to find `switch:N` and `cover:N` components
 - **Generic metrics collection** (`rpc/main.go`) - iterates over discovered components instead of matching device types; WiFi metrics always collected
+- **HTTP digest auth** (`client/api_client.go`) - implements Shelly Gen2 digest authentication (SHA-256, user `admin`). The `username`/`password` config fields were previously inert; they now authenticate, and a global credential can be supplied via environment variables (see Authentication).
 - **Dockerfile** - removed bundled `config.yaml`, clean entrypoint accepting `--config` flag
 - **CI workflows** - use `GITHUB_TOKEN` instead of custom `TOKEN` secret
 
@@ -46,6 +47,27 @@ devices:
 | `devices[].host` | Device IP address | (required) |
 | `devices[].username` | Auth username (if enabled) | (empty) |
 | `devices[].password` | Auth password (if enabled) | (empty) |
+
+### Authentication
+
+Shelly Gen2+ devices use HTTP digest auth (SHA-256, account `admin`). When a
+device has auth enabled, supply the password and the exporter authenticates
+automatically.
+
+Two ways to provide credentials (per-device config wins over the environment):
+
+- **Per-device** in `config.yaml` via `devices[].username` / `devices[].password`.
+- **Global** via environment variables, applied to every device that has no
+  explicit credential:
+
+  | Env var | Description | Default |
+  |---|---|---|
+  | `SHELLY_USERNAME` | Auth username for all devices | `admin` (used when a password is set) |
+  | `SHELLY_PASSWORD` | Auth password for all devices | (empty) |
+
+The global option suits a fleet that shares one admin password and a config
+listing only hosts (e.g. one rendered by an operator): set `SHELLY_PASSWORD`
+once and every device authenticates as `admin`.
 
 ### Endpoints
 

--- a/client/api_client.go
+++ b/client/api_client.go
@@ -1,6 +1,9 @@
 package client
 
 import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -9,34 +12,74 @@ import (
 	"regexp"
 	"sort"
 	"strconv"
+	"strings"
+	"sync"
 	"time"
 )
 
 type APIClient struct {
-	BaseURL string
-	Client  *http.Client
+	BaseURL  string
+	Username string
+	Password string
+	Client   *http.Client
+
+	mu   sync.Mutex
+	auth *digestState // cached challenge, populated after the first 401
 }
 
-// NewAPIClient initializes and returns a new APIClient.
-func NewAPIClient(baseURL string, timeout time.Duration) *APIClient {
+// digestState holds a parsed WWW-Authenticate digest challenge. nc is the
+// request counter incremented on each authenticated request that reuses the
+// cached nonce.
+type digestState struct {
+	realm  string
+	nonce  string
+	opaque string
+	nc     uint32
+}
+
+// NewAPIClient initializes and returns a new APIClient. A non-empty
+// username/password enables Shelly Gen2 HTTP digest auth (SHA-256, qop=auth);
+// pass empty strings to talk to a device with auth disabled.
+func NewAPIClient(baseURL, username, password string, timeout time.Duration) *APIClient {
 	return &APIClient{
-		BaseURL: baseURL,
+		BaseURL:  baseURL,
+		Username: username,
+		Password: password,
 		Client: &http.Client{
 			Timeout: timeout,
 		},
 	}
 }
 
-// FetchData makes a GET request to the specified endpoint and parses the response.
+// FetchData makes a GET request to the specified endpoint and parses the
+// response. When a password is configured and the device answers 401, it
+// answers the digest challenge and retries once.
 func (c *APIClient) FetchData(endpoint string, result interface{}) error {
 	url := fmt.Sprintf("http://%s%s", c.BaseURL, endpoint)
 	slog.Info("Fetching data", slog.String("url", url))
 
-	resp, err := c.Client.Get(url)
+	resp, err := c.do(endpoint, url)
 	if err != nil {
 		slog.Error("Failed to fetch data", slog.String("url", url), slog.Any("error", err))
 		return fmt.Errorf("failed to fetch data from %s: %w", url, err)
 	}
+
+	// Answer a digest challenge once, then retry, when we hold a password.
+	if resp.StatusCode == http.StatusUnauthorized && c.Password != "" {
+		challenge := resp.Header.Get("WWW-Authenticate")
+		_, _ = io.Copy(io.Discard, resp.Body) // drain so the connection can be reused
+		_ = resp.Body.Close()
+		if err := c.setChallenge(challenge); err != nil {
+			slog.Error("Digest auth failed", slog.String("url", url), slog.Any("error", err))
+			return fmt.Errorf("digest auth for %s: %w", url, err)
+		}
+		resp, err = c.do(endpoint, url)
+		if err != nil {
+			slog.Error("Failed to fetch data", slog.String("url", url), slog.Any("error", err))
+			return fmt.Errorf("failed to fetch data from %s: %w", url, err)
+		}
+	}
+
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
 			slog.Error("Failed to close response body", slog.Any("error", err))
@@ -61,6 +104,80 @@ func (c *APIClient) FetchData(endpoint string, result interface{}) error {
 
 	slog.Info("Successfully fetched data", slog.String("url", url))
 	return nil
+}
+
+// do issues a GET, attaching an Authorization header when a digest challenge
+// has already been cached.
+func (c *APIClient) do(endpoint, url string) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	c.mu.Lock()
+	if c.auth != nil && c.Password != "" {
+		c.auth.nc++
+		req.Header.Set("Authorization", c.authorizationLocked(http.MethodGet, endpoint, c.auth.nc))
+	}
+	c.mu.Unlock()
+	return c.Client.Do(req)
+}
+
+var digestFieldRe = regexp.MustCompile(`(\w+)=(?:"([^"]*)"|([^",\s]+))`)
+
+// setChallenge parses a WWW-Authenticate digest header and caches its
+// parameters for subsequent requests.
+func (c *APIClient) setChallenge(header string) error {
+	if !strings.HasPrefix(strings.ToLower(strings.TrimSpace(header)), "digest") {
+		return fmt.Errorf("not a digest challenge: %q", header)
+	}
+	fields := map[string]string{}
+	for _, m := range digestFieldRe.FindAllStringSubmatch(header, -1) {
+		v := m[2]
+		if v == "" {
+			v = m[3]
+		}
+		fields[strings.ToLower(m[1])] = v
+	}
+	if fields["realm"] == "" || fields["nonce"] == "" {
+		return fmt.Errorf("incomplete digest challenge: %q", header)
+	}
+	c.mu.Lock()
+	c.auth = &digestState{realm: fields["realm"], nonce: fields["nonce"], opaque: fields["opaque"]}
+	c.mu.Unlock()
+	return nil
+}
+
+// authorizationLocked builds the Digest Authorization header value. The caller
+// must hold c.mu (it reads c.auth).
+func (c *APIClient) authorizationLocked(method, uri string, nc uint32) string {
+	ha1 := sha256hex(c.Username + ":" + c.auth.realm + ":" + c.Password)
+	ha2 := sha256hex(method + ":" + uri)
+	ncStr := fmt.Sprintf("%08x", nc)
+	cnonce := randomHex(8)
+	response := sha256hex(strings.Join([]string{ha1, c.auth.nonce, ncStr, cnonce, "auth", ha2}, ":"))
+	h := fmt.Sprintf(
+		`Digest username=%q, realm=%q, nonce=%q, uri=%q, response=%q, qop=auth, nc=%s, cnonce=%q, algorithm=SHA-256`,
+		c.Username, c.auth.realm, c.auth.nonce, uri, response, ncStr, cnonce,
+	)
+	if c.auth.opaque != "" {
+		h += fmt.Sprintf(`, opaque=%q`, c.auth.opaque)
+	}
+	return h
+}
+
+func sha256hex(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}
+
+func randomHex(n int) string {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		// crypto/rand.Read does not fail in practice; keep a valid-length
+		// fallback so the header stays well-formed.
+		return strings.Repeat("0", 2*n)
+	}
+	return hex.EncodeToString(b)
 }
 
 var componentKeyRe = regexp.MustCompile(`^(switch|cover):(\d+)$`)

--- a/client/api_client_test.go
+++ b/client/api_client_test.go
@@ -1,0 +1,142 @@
+package client
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// parseDigestHeader extracts the fields of a Digest Authorization header using
+// the same regex the client uses to parse challenges.
+func parseDigestHeader(h string) map[string]string {
+	out := map[string]string{}
+	for _, m := range digestFieldRe.FindAllStringSubmatch(h, -1) {
+		v := m[2]
+		if v == "" {
+			v = m[3]
+		}
+		out[strings.ToLower(m[1])] = v
+	}
+	return out
+}
+
+// validDigest independently recomputes the RFC digest response from the
+// header the client sent and reports whether it matches (i.e. the client
+// authenticated correctly).
+func validDigest(header, method, realm, nonce, user, pass string) bool {
+	f := parseDigestHeader(header)
+	if f["username"] != user || f["realm"] != realm || f["nonce"] != nonce || f["qop"] != "auth" {
+		return false
+	}
+	ha1 := sha256hex(user + ":" + realm + ":" + pass)
+	ha2 := sha256hex(method + ":" + f["uri"])
+	want := sha256hex(strings.Join([]string{ha1, nonce, f["nc"], f["cnonce"], "auth", ha2}, ":"))
+	return f["response"] == want
+}
+
+func TestFetchDataDigestAuth(t *testing.T) {
+	const realm, nonce, user, pass = "shellyplugus-test", "deadbeefnonce", "admin", "s3cret-pw"
+	var authed bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authz := r.Header.Get("Authorization")
+		if authz == "" || !validDigest(authz, r.Method, realm, nonce, user, pass) {
+			w.Header().Set("WWW-Authenticate",
+				`Digest qop="auth", realm="`+realm+`", nonce="`+nonce+`", algorithm=SHA-256`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		authed = true
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"value":42}`))
+	}))
+	defer srv.Close()
+
+	c := NewAPIClient(strings.TrimPrefix(srv.URL, "http://"), user, pass, 5*time.Second)
+	var out struct {
+		Value int `json:"value"`
+	}
+	if err := c.FetchData("/rpc/Shelly.GetStatus", &out); err != nil {
+		t.Fatalf("FetchData: %v", err)
+	}
+	if out.Value != 42 {
+		t.Fatalf("value = %d, want 42", out.Value)
+	}
+	if !authed {
+		t.Fatal("server never accepted a valid digest response")
+	}
+}
+
+// After the first challenge the client should reuse the cached nonce and send
+// Authorization pre-emptively (with an incrementing nc), not re-challenge.
+func TestFetchDataReusesCachedChallenge(t *testing.T) {
+	const realm, nonce, user, pass = "shelly-test", "noncevalue", "admin", "pw"
+	challenges := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authz := r.Header.Get("Authorization")
+		if authz == "" || !validDigest(authz, r.Method, realm, nonce, user, pass) {
+			challenges++
+			w.Header().Set("WWW-Authenticate",
+				`Digest qop="auth", realm="`+realm+`", nonce="`+nonce+`", algorithm=SHA-256`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	c := NewAPIClient(strings.TrimPrefix(srv.URL, "http://"), user, pass, 5*time.Second)
+	var out map[string]any
+	for i := 0; i < 3; i++ {
+		if err := c.FetchData("/rpc/Shelly.GetStatus", &out); err != nil {
+			t.Fatalf("request %d: %v", i, err)
+		}
+	}
+	if challenges != 1 {
+		t.Fatalf("got %d challenges, want exactly 1 (nonce should be cached and reused)", challenges)
+	}
+}
+
+func TestFetchDataNoPasswordSendsNoAuth(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			t.Error("unexpected Authorization header when no password configured")
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"value":7}`))
+	}))
+	defer srv.Close()
+
+	c := NewAPIClient(strings.TrimPrefix(srv.URL, "http://"), "", "", 5*time.Second)
+	var out struct {
+		Value int `json:"value"`
+	}
+	if err := c.FetchData("/rpc/Shelly.GetStatus", &out); err != nil {
+		t.Fatalf("FetchData: %v", err)
+	}
+	if out.Value != 7 {
+		t.Fatalf("value = %d, want 7", out.Value)
+	}
+}
+
+func TestFetchDataWrongPasswordSurfacesError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Always reject - simulates a bad password.
+		w.Header().Set("WWW-Authenticate",
+			`Digest qop="auth", realm="r", nonce="n", algorithm=SHA-256`)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	c := NewAPIClient(strings.TrimPrefix(srv.URL, "http://"), "admin", "wrong", 5*time.Second)
+	var out map[string]any
+	err := c.FetchData("/rpc/Shelly.GetStatus", &out)
+	if err == nil {
+		t.Fatal("expected an error for a rejected password, got nil")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Fatalf("expected a 401 error, got: %v", err)
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -42,7 +42,33 @@ func NewConfig(configPath string) (*YamlConfig, error) {
 		return nil, err
 	}
 
+	applyCredentialDefaults(config)
 	return config, nil
+}
+
+// applyCredentialDefaults fills empty per-device credentials from the global
+// SHELLY_USERNAME / SHELLY_PASSWORD environment variables. This lets the
+// operator-rendered config carry hosts only while one shared admin password is
+// supplied via the environment. A device that ends up with a password but no
+// username defaults to "admin" (the Shelly Gen2 account). Explicit per-device
+// values in the config file always win.
+func applyCredentialDefaults(cfg *YamlConfig) {
+	envUser := os.Getenv("SHELLY_USERNAME")
+	envPass := os.Getenv("SHELLY_PASSWORD")
+	for i := range cfg.Devices {
+		d := &cfg.Devices[i]
+		if d.Password == "" {
+			d.Password = envPass
+		}
+		if d.Username == "" {
+			switch {
+			case envUser != "":
+				d.Username = envUser
+			case d.Password != "":
+				d.Username = "admin"
+			}
+		}
+	}
 }
 
 // ParseFlags will create and parse the CLI flags

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,53 @@
+package config
+
+import "testing"
+
+func TestApplyCredentialDefaultsEnvFallback(t *testing.T) {
+	t.Setenv("SHELLY_USERNAME", "")
+	t.Setenv("SHELLY_PASSWORD", "envpass")
+
+	cfg := &YamlConfig{Devices: []DeviceYamlConfig{
+		{Host: "a"}, // empty -> env pass, admin user
+		{Host: "b", Username: "u", Password: "p"}, // explicit -> preserved
+		{Host: "c", Password: "explicit"},         // pass kept, user -> admin
+		{Host: "d", Username: "custom"},           // explicit user, no pass -> env pass, user kept
+	}}
+	applyCredentialDefaults(cfg)
+
+	if cfg.Devices[0].Password != "envpass" || cfg.Devices[0].Username != "admin" {
+		t.Errorf("device a: got %+v, want password=envpass username=admin", cfg.Devices[0])
+	}
+	if cfg.Devices[1].Username != "u" || cfg.Devices[1].Password != "p" {
+		t.Errorf("device b: explicit creds not preserved: %+v", cfg.Devices[1])
+	}
+	if cfg.Devices[2].Password != "explicit" || cfg.Devices[2].Username != "admin" {
+		t.Errorf("device c: got %+v, want password=explicit username=admin", cfg.Devices[2])
+	}
+	if cfg.Devices[3].Username != "custom" || cfg.Devices[3].Password != "envpass" {
+		t.Errorf("device d: got %+v, want username=custom password=envpass", cfg.Devices[3])
+	}
+}
+
+func TestApplyCredentialDefaultsExplicitEnvUser(t *testing.T) {
+	t.Setenv("SHELLY_USERNAME", "operator")
+	t.Setenv("SHELLY_PASSWORD", "envpass")
+
+	cfg := &YamlConfig{Devices: []DeviceYamlConfig{{Host: "a"}}}
+	applyCredentialDefaults(cfg)
+
+	if cfg.Devices[0].Username != "operator" || cfg.Devices[0].Password != "envpass" {
+		t.Errorf("got %+v, want username=operator password=envpass", cfg.Devices[0])
+	}
+}
+
+func TestApplyCredentialDefaultsNoEnvLeavesEmpty(t *testing.T) {
+	t.Setenv("SHELLY_USERNAME", "")
+	t.Setenv("SHELLY_PASSWORD", "")
+
+	cfg := &YamlConfig{Devices: []DeviceYamlConfig{{Host: "a"}}}
+	applyCredentialDefaults(cfg)
+
+	if cfg.Devices[0].Username != "" || cfg.Devices[0].Password != "" {
+		t.Errorf("expected empty creds with no env, got %+v", cfg.Devices[0])
+	}
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":semanticCommits",
+    ":timezone(Europe/London)"
+  ],
+  "packageRules": [
+    {
+      "description": "Auto-merge GitHub Actions minor/patch/digest",
+      "matchManagers": ["github-actions"],
+      "automerge": true,
+      "automergeType": "branch",
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "minimumReleaseAge": "3 days"
+    }
+  ]
+}

--- a/rpc/main.go
+++ b/rpc/main.go
@@ -42,7 +42,7 @@ func (dm *DeviceManager) RegisterDevice(device *DeviceConfig, updateInterval tim
 
 	slog.Info("Registering new device", slog.String("host", device.Host))
 
-	apiClient := client.NewAPIClient(device.Host, 10*time.Second)
+	apiClient := client.NewAPIClient(device.Host, device.Username, device.Password, 10*time.Second)
 	ctx, cancel := context.WithCancel(context.Background())
 
 	// Initialize device type

--- a/rpc/shelly.go
+++ b/rpc/shelly.go
@@ -1,10 +1,12 @@
 package rpc
 
 type DeviceConfig struct {
-	Host     string
-	Username string
-	Password string
-	Type     string
-	Mac      string
-	Profile  string
+	Host      string
+	Username  string
+	Password  string
+	Type      string
+	Mac       string
+	Profile   string
+	SwitchIDs []int
+	CoverIDs  []int
 }


### PR DESCRIPTION
## Why

The exporter's `devices[].username`/`devices[].password` config fields existed but were **never used** -- the HTTP client (`client.FetchData`) made unauthenticated GETs. Any Shelly device with auth enabled returns `401` and produces no metrics. This is the prerequisite for enabling device auth across the fleet without losing metrics (the "exporter-first" step of the fleet auth rollout).

## What

- **`client/api_client.go`** -- implement Shelly Gen2 digest auth (SHA-256, `qop=auth`, user `admin`). On `401`, parse the `WWW-Authenticate` challenge, compute the digest response, and retry once. Cache the nonce and reuse it on subsequent requests (incrementing `nc`); re-challenge automatically on a stale nonce. `sync.Mutex` guards the cached challenge.
- **`config/config.go`** -- global credential fallback via env vars `SHELLY_USERNAME` (default `admin` when a password is present) / `SHELLY_PASSWORD`, applied to any device without explicit per-device creds. Per-device config always wins.
- **`rpc/main.go`** -- pass the device credentials into `NewAPIClient` (previously dropped).
- **Tests** (first in the repo): digest `401`->retry with independent server-side digest verification, nonce caching/reuse, no-auth path, wrong-password surfaces an error, and credential-precedence cases.
- **README** -- document the digest support + env vars.

## Deploy note

The deployment renders a **hosts-only** config, so set the shared admin password via env (`SHELLY_PASSWORD`, from a Secret) on the container; every device then authenticates as `admin`. No config-file change needed.

## Verification

`go build ./...`, `go vet ./...`, and `go test -race ./client/... ./config/...` all pass. Reviewed against the operator's proven digest implementation.